### PR TITLE
fix: offsets changes after CS:S 24.08.26 update

### DIFF
--- a/addons/sourcemod/gamedata/CashManager.games.txt
+++ b/addons/sourcemod/gamedata/CashManager.games.txt
@@ -31,7 +31,7 @@
 			"AddAccountLen"
 			{
 				"windows"		"278" // Outdated ?
-				"linux"			"1163"
+				"linux"			"1168"
 			}
 		}
 	}

--- a/addons/sourcemod/scripting/CashManager.sp
+++ b/addons/sourcemod/scripting/CashManager.sp
@@ -16,7 +16,7 @@ public Plugin myinfo =
 	name = "CashManager",
 	author = "Dr!fter, .Rushaway",
 	description = "Patches max money",
-	version = "1.1.0"
+	version = "1.2.0"
 }
 
 public APLRes AskPluginLoad2(Handle myself, bool late, char[] error, int err_max)


### PR DESCRIPTION
Function length changed from 1163 to 1168 (5 additional bytes):

Start Address as shown in the screenshot is: *0x007058D0*
<img width="1240" height="508" alt="Start_Addr" src="https://github.com/user-attachments/assets/e712cd10-4d47-470f-ba77-48a91c29b9d8" />

End Address as shown in the screenshot is: *0x00705D60*
<img width="1198" height="278" alt="End_Addr" src="https://github.com/user-attachments/assets/aadc4f38-82ca-4130-9250-7952e11259f7" />

Length = End Addr - Start Addr = 0x00705D60 - 0x007058D0 = 1168
